### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/message.go
+++ b/message.go
@@ -25,7 +25,7 @@ func (m RawNetlinkMessage) toRawMsg() syscall.NetlinkMessage {
 
 // Higher level implementation: let's suppose we're on a little-endian platform
 
-// Write a netlink message to a socket
+// WriteMessage writes a netlink message to a socket
 func WriteMessage(s *NetlinkConn, m NetlinkMsg) error {
 	w := bytes.NewBuffer(nil)
 	msg := m.toRawMsg()
@@ -39,7 +39,7 @@ func WriteMessage(s *NetlinkConn, m NetlinkMsg) error {
 	return er
 }
 
-// Reads a netlink message from a socket
+// ReadMessage reads a netlink message from a socket
 func ReadMessage(s *NetlinkConn) (msg syscall.NetlinkMessage, er error) {
 	binary.Read(s.rbuf, SystemEndianness, &msg.Header)
 	msg.Data = make([]byte, msg.Header.Len-syscall.NLMSG_HDRLEN)


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?